### PR TITLE
Check whether move-to-content succeeded

### DIFF
--- a/json-rpc-tests.el
+++ b/json-rpc-tests.el
@@ -20,6 +20,11 @@
     (should (>= (json-rpc bitcoind "getbalance") 0.0))
     (should-error (json-rpc "bogusmethod" 1 2 3))))
 
+(ert-deftest json-rpc-incomplete-response ()
+  (insert "HTTP/1.1 200 OK\r\n"
+          "Content-Length: 10\r\n")
+  (should-not (json-rpc--content-finished-p)))
+
 (provide 'json-rpc-tests)
 
 ;;; json-rpc-tests.el ends here

--- a/json-rpc.el
+++ b/json-rpc.el
@@ -103,8 +103,9 @@
   (setf (point) (point-min))
   (when (search-forward "Content-Length: " nil t)
     (let ((length (read (current-buffer))))
-      (json-rpc--move-to-content)
-      (<= length (- (position-bytes (point-max)) (position-bytes (point)))))))
+      (and (json-rpc--move-to-content)
+           (<= length (- (position-bytes (point-max))
+                         (position-bytes (point))))))))
 
 (defun json-rpc-wait (connection)
   "Wait for the response from CONNECTION and return it, or signal the error."


### PR DESCRIPTION
If the body separator is not yet present, (point) will equal (point-min) and the length check is invalid for small values of Content-Length. Pretty tricky bug! :)
