### PR TITLE
Add Content-Type header

### DIFF
--- a/json-rpc.el
+++ b/json-rpc.el
@@ -88,6 +88,7 @@
     (with-temp-buffer
       (insert (format "POST %s HTTP/1.1\r\n" (url-encode-url endpoint)))
       (when auth (insert "Authorization: Basic " auth "\r\n"))
+      (insert "Content-Type: application/json\r\n")      
       (insert (format "Content-Length: %d\r\n\r\n" (string-bytes encoded))
               encoded)
       (process-send-region process (point-min) (point-max)))


### PR DESCRIPTION
Hi! 

Some implementation require that `Content-Type: application/json` is specified (for example, [this one](https://github.com/paritytech/jsonrpc/blob/3fd82a5ad9b10e55e89682f228afc72c321b7a8b/minihttp/src/lib.rs#L219)), so let's add this header?